### PR TITLE
fix: generate properly sized thumbnails

### DIFF
--- a/src/ffmpeg-audio-thumbnailer.thumbnailer
+++ b/src/ffmpeg-audio-thumbnailer.thumbnailer
@@ -1,4 +1,4 @@
 [Thumbnailer Entry]
 TryExec=ffmpeg
-Exec=ffmpeg -y -i %i %o -fs %s
+Exec=ffmpeg -y -i %i -frames:v 1 -update 1 -vf scale=%s:-1 %o
 MimeType=audio/mpeg;audio/flac;audio/wavpack;audio/webm;audio/mp4;audio/aac;audio/x-matroska;audio/x-opus+ogg


### PR DESCRIPTION
The current command generates full-sized thumbnails which wastes a lot of space in ~/.cache. Instead, set the width to `%s` and scale the height to match the aspect ratio.